### PR TITLE
Consertando a logo dentro do menu responsivo

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2962,7 +2962,6 @@
 
 					#header > header .avatar {
 						margin: 0 auto 1.6875em auto;
-						width: 6em;
 					}
 
 					#header > header h1 {

--- a/src/components/organisms/navigation/Navigation.vue
+++ b/src/components/organisms/navigation/Navigation.vue
@@ -2,7 +2,7 @@
 
   section#header
     header
-      perfil(:perfil='{ description: "Javascript de mulheres para mulheres", logo: "{ JS Ladies }" }')
+      perfil(:perfil='{ description: "JavaScript de mulheres para mulheres", logo: "{ JS Ladies }" }')
     nav(id="nav", class="navigation")
       main-menu(:options='menu')
     footer


### PR DESCRIPTION
O que foi feito?
- Conserto da logo dentro do menu responsivo
- Conserto de gramática (JavaScript ao invés de Javascript) no menu

Por que foi feito?
- A logo estava achatada e com alguns pedaços faltando em volta

Como foi feito?
- No responsivo, removi o width que deixava a logo achatada

This PR resolves Issue #7 